### PR TITLE
throttle interval fIx for android

### DIFF
--- a/android/src/main/kotlin/com/meg4cyberc4t/varioqub_configs/VarioqubApiPigeonImpl.kt
+++ b/android/src/main/kotlin/com/meg4cyberc4t/varioqub_configs/VarioqubApiPigeonImpl.kt
@@ -43,7 +43,7 @@ class VarioqubApiPigeonImpl : FlutterPlugin, VarioqubApiPigeon {
             builder.withUrl(settings.url).also { builder = it }
         }
         if (settings.fetchThrottleIntervalMs != null) {
-            builder.withThrottleInterval(settings.fetchThrottleIntervalMs).also { builder = it }
+            builder.withThrottleInterval(settings.fetchThrottleIntervalMs / 1000).also { builder = it }
         }
         settings.clientFeatures.forEach { (key, value) ->
             if (key == null || value == null) return


### PR DESCRIPTION
Кажется, что тут вообще нет смысла задавать в ms, раз на обеих платформах принимается в sec.
А ещё было бы здорово на стороне Flutter сделать Duration вместо int