### PR TITLE
AppMetrica dependency updated to actual on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         implementation 'com.yandex.varioqub:appmetrica-adapter:0.7.0'
         implementation 'com.yandex.varioqub:config:0.7.0'
-        implementation 'com.yandex.android:mobmetricalib:5.3.0'
+        implementation 'io.appmetrica.analytics:analytics:7.2.0'
     }
 
     testOptions {


### PR DESCRIPTION
mobmetricalib устарела, и команда Метрики не рекомендует использовать её в одном проекте вместе c io.appmetrica.analytics - а в appmetrica_plugin как раз используется она